### PR TITLE
Use default `RangeData` message instance

### DIFF
--- a/core/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
+++ b/core/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
@@ -119,7 +119,7 @@ class LakeFSInputFormat
     fs.copyToLocalFile(p, new Path(localFile.getAbsolutePath))
     val rangesReader = new SSTableReader(
       localFile.getAbsolutePath,
-      RangeData.newBuilder().build(),
+      RangeData.getDefaultInstance,
     )
     localFile.delete()
     val ranges = read(rangesReader)


### PR DESCRIPTION
More idiomatic protobuf, mildly more efficient (don't create an unused object), but does *not*
help resolve issues with thin JARs.