### PR TITLE
Cross-compile for Spark 2.4.7, 3.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,7 @@ isSnapshot := true
 
 // Spark versions 2.4.7 and 3.0.1 use different Scala versions.  Changing this is a deep
 // change, so key the Spark distinction by the Scala distinction.  sbt doesn't appear to
-// support other ways of changing emitted Scala binary versions using the same compiler,
-// sigh...
+// support other ways of changing emitted Scala binary versions using the same compiler.
 
 // SO https://stackoverflow.com/a/60177627/192263 hints that we cannot use 2.11 here before
 // this version

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,6 @@ lazy val commonSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
-  // Currently cannot publish docs, possibly need to shade Google protobufs better
   publishTo := {
     val nexus = "https://s01.oss.sonatype.org/"
     if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")

--- a/build.sbt
+++ b/build.sbt
@@ -14,20 +14,15 @@ isSnapshot := true
 lazy val scala211Version = "2.11.12"
 lazy val scala212Version = "2.12.12"
 
-def settingsToCompileIn(dir: String) = Seq(
-  /*
-   * Define the scala sources relative to the sub-directory the project source. The
-   * individual projects have their sources defined in `./target/${projectName}`,
-   * therefore `./src` lives two directories above base. Also do this for `resources`
-   * etc, if needed.
-   */
-  Compile / scalaSource := baseDirectory.value / ".." / ".." / dir / "src" / "main" / "scala",
-  Test / scalaSource := baseDirectory.value / ".." / ".." / dir / "src" / "test" / "scala",
-  Compile / resourceDirectory := baseDirectory.value / ".." / ".." / dir / "src" / "main" / "resources",
-  Compile / PB.includePaths += (ThisBuild / baseDirectory).value / dir / "src" / "main" / "resources",
-  Compile / PB.protoSources += (ThisBuild / baseDirectory).value / dir / "src" / "main" / "resources",
-)
-
+def settingsToCompileIn(dir: String) = {
+  Seq(
+    Compile / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "scala",
+    Test / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "test" / "scala",
+    Compile / resourceDirectory := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "resources",
+    Compile / PB.includePaths += (Compile / resourceDirectory).value,
+    Compile / PB.protoSources += (Compile / resourceDirectory).value,
+  )
+}
 
 def generateCoreProject(buildType: BuildType) =
   Project(s"core-${buildType.name}", file(s"target/core-${buildType.name}"))

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ def generateProject(buildType: BuildType) = {
       libraryDependencies ++= Seq("org.rocksdb" % "rocksdbjni" % "6.6.4",
         "commons-codec" % "commons-codec" % "1.15",
         "org.apache.spark" %% "spark-sql" % buildType.sparkVersion % "provided",
-        "com.thesamet.scalapb" %% "scalapb-runtime" % buildType.scalapbVersion % "protobuf" exclude("com.google.protobuf", "protobuf-java"),
+        "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
         "org.apache.hadoop" % "hadoop-aws" % buildType.hadoopVersion,
         "org.apache.hadoop" % "hadoop-common" % buildType.hadoopVersion,
         "org.scalaj" %% "scalaj-http" % "2.4.2",

--- a/core/src/main/resources/google/protobuf/timestamp.proto
+++ b/core/src/main/resources/google/protobuf/timestamp.proto
@@ -1,0 +1,138 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
+option go_package = "github.com/golang/protobuf/ptypes/timestamp";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "TimestampProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+
+// A Timestamp represents a point in time independent of any time zone or local
+// calendar, encoded as a count of seconds and fractions of seconds at
+// nanosecond resolution. The count is relative to an epoch at UTC midnight on
+// January 1, 1970, in the proleptic Gregorian calendar which extends the
+// Gregorian calendar backwards to year one.
+//
+// All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+// second table is needed for interpretation, using a [24-hour linear
+// smear](https://developers.google.com/time/smear).
+//
+// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+// restricting to that range, we ensure that we can convert to and from [RFC
+// 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+//
+// # Examples
+//
+// Example 1: Compute Timestamp from POSIX `time()`.
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(time(NULL));
+//     timestamp.set_nanos(0);
+//
+// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+//
+//     struct timeval tv;
+//     gettimeofday(&tv, NULL);
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(tv.tv_sec);
+//     timestamp.set_nanos(tv.tv_usec * 1000);
+//
+// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+//
+//     FILETIME ft;
+//     GetSystemTimeAsFileTime(&ft);
+//     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+//
+//     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+//     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+//     Timestamp timestamp;
+//     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+//     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+//
+// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+//
+//     long millis = System.currentTimeMillis();
+//
+//     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+//         .setNanos((int) ((millis % 1000) * 1000000)).build();
+//
+//
+// Example 5: Compute Timestamp from current time in Python.
+//
+//     timestamp = Timestamp()
+//     timestamp.GetCurrentTime()
+//
+// # JSON Mapping
+//
+// In JSON format, the Timestamp type is encoded as a string in the
+// [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+// format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+// where {year} is always expressed using four digits while {month}, {day},
+// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+// is required. A proto3 JSON serializer should always use UTC (as indicated by
+// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+// able to accept both UTC and other timezones (as indicated by an offset).
+//
+// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+// 01:30 UTC on January 15, 2017.
+//
+// In JavaScript, one can convert a Date object to this format using the
+// standard
+// [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+// method. In Python, a standard `datetime.datetime` object can be converted
+// to this format using
+// [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+// the Joda Time's [`ISODateTimeFormat.dateTime()`](
+// http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+// ) to obtain a formatter capable of generating timestamps in this format.
+//
+//
+message Timestamp {
+  // Represents seconds of UTC time since Unix epoch
+  // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+  // 9999-12-31T23:59:59Z inclusive.
+  int64 seconds = 1;
+
+  // Non-negative fractions of a second at nanosecond resolution. Negative
+  // second values with fractions must still have non-negative nanos values
+  // that count forward in time. Must be from 0 to 999,999,999
+  // inclusive.
+  int32 nanos = 2;
+}

--- a/core/src/main/scala/io/treeverse/clients/Reader.scala
+++ b/core/src/main/scala/io/treeverse/clients/Reader.scala
@@ -1,7 +1,0 @@
-package io.treeverse.clients
-
-import com.google.protobuf.Message
-
-trait ProtoReader[Proto <: Message] {
-  def get(ID : Array[Byte]) : Seq[EntryRecord[Proto]]
-}

--- a/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
+++ b/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
@@ -17,7 +17,7 @@ private object local {
   }
 }
 
-class SSTableIterator[Proto <: GeneratedMessage](val it: SstFileReaderIterator, companion: GeneratedMessageCompanion[Proto]) extends Iterator[Item[Proto]] with Closeable {
+class SSTableIterator[Proto <: GeneratedMessage with scalapb.Message[Proto]](val it: SstFileReaderIterator, companion: GeneratedMessageCompanion[Proto]) extends Iterator[Item[Proto]] with Closeable {
   // TODO(ariels): explicitly make it closeable, and figure out how to close it when used by
   //     Spark.
   override def hasNext: Boolean = it.isValid
@@ -50,7 +50,7 @@ object SSTableReader {
   RocksDB.loadLibrary()
 }
 
-class SSTableReader[Proto <: GeneratedMessage](sstableFile: String, companion: GeneratedMessageCompanion[Proto]) extends Closeable {
+class SSTableReader[Proto <: GeneratedMessage with scalapb.Message[Proto]](sstableFile: String, companion: GeneratedMessageCompanion[Proto]) extends Closeable {
   private val options = new Options
   private val reader = new SstFileReader(options)
   private val readOptions = new ReadOptions

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.25")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.11"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.7"

--- a/project/types.scala
+++ b/project/types.scala
@@ -1,0 +1,9 @@
+package build
+
+class BuildType(
+  val name: String,
+  val scalaVersion: String,
+  val sparkVersion: String,
+  val scalapbVersion: String,
+  val hadoopVersion: String,
+)


### PR DESCRIPTION


Testing:

```
ariels@redqueen:~/dev/spark-client$ SPARK_HOME=$HOME/dev/spark-2.4.7-bin-hadoop2.7   spark-shell --master local --packages io.treeverse:core-247_2.11:0.1.0-SNAPSHOT  --conf spark.hadoop.lakefs.api.url=http://yoni-test.lakefs.dev/api/v1  --conf spark.hadoop.lakefs.api.access_key=AKIA... --conf spark.hadoop.lakefs.api.secret_key=... --conf spark.hadoop.fs.s3a.access.key=AKIA... --conf spark.hadoop-fs.s3a.secret.key=...
Ivy Default Cache set to: /home/ariels/.ivy2/cache
The jars for the packages stored in: /home/ariels/.ivy2/jars
:: loading settings :: url = jar:file:/home/ariels/dev/spark-2.4.7-bin-hadoop2.7/jars/ivy-2.4.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
io.treeverse#core-247_2.11 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-9701fd43-edf3-4326-882f-e66c357e86f5;1.0
        confs: [default]
        found io.treeverse#core-247_2.11;0.1.0-SNAPSHOT in local-ivy-cache
        [0.1.0-SNAPSHOT] io.treeverse#core-247_2.11;0.1.0-SNAPSHOT
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.ivy.util.url.IvyAuthenticator (file:/home/ariels/dev/spark-2.4.7-bin-hadoop2.7/jars/ivy-2.4.0.jar) to field java.net.Authenticator.theAuthenticator
WARNING: Please consider reporting this to the maintainers of org.apache.ivy.util.url.IvyAuthenticator
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
        found com.thesamet.scalapb#scalapb-runtime_2.11;0.9.7 in central
        found com.thesamet.scalapb#lenses_2.11;0.9.7 in central
        found com.google.protobuf#protobuf-java;3.8.0 in central
        found com.lihaoyi#fastparse_2.11;2.1.2 in central
        found com.lihaoyi#sourcecode_2.11;0.1.6 in central
        found org.rocksdb#rocksdbjni;6.6.4 in central
        found commons-codec#commons-codec;1.15 in local-m2-cache
        found org.apache.hadoop#hadoop-aws;2.7.7 in central
        found org.apache.hadoop#hadoop-common;2.7.7 in central
        found org.apache.hadoop#hadoop-annotations;2.7.7 in central
        found commons-cli#commons-cli;1.2 in local-m2-cache
        found org.apache.commons#commons-math3;3.1.1 in central
        found xmlenc#xmlenc;0.52 in local-m2-cache
        found commons-httpclient#commons-httpclient;3.1 in local-m2-cache
        found commons-logging#commons-logging;1.1.3 in local-m2-cache
        found commons-io#commons-io;2.4 in local-m2-cache
        found commons-net#commons-net;3.1 in local-m2-cache
        found commons-collections#commons-collections;3.2.2 in local-m2-cache
        found javax.servlet#servlet-api;2.5 in central
        found org.mortbay.jetty#jetty;6.1.26 in central
        found org.mortbay.jetty#jetty-util;6.1.26 in local-m2-cache
        found org.mortbay.jetty#jetty-sslengine;6.1.26 in central
        found com.sun.jersey#jersey-core;1.9 in central
        found com.sun.jersey#jersey-json;1.9 in central
        found org.codehaus.jettison#jettison;1.1 in local-m2-cache
        found com.sun.xml.bind#jaxb-impl;2.2.3-1 in local-m2-cache
        found javax.xml.bind#jaxb-api;2.2.2 in local-m2-cache
        found javax.xml.stream#stax-api;1.0-2 in local-m2-cache
        found javax.activation#activation;1.1 in central
        found org.codehaus.jackson#jackson-core-asl;1.9.13 in local-m2-cache
        found org.codehaus.jackson#jackson-mapper-asl;1.9.13 in local-m2-cache
        found org.codehaus.jackson#jackson-jaxrs;1.9.13 in local-m2-cache
        found org.codehaus.jackson#jackson-xc;1.9.13 in local-m2-cache
        found com.sun.jersey#jersey-server;1.9 in central
        found asm#asm;3.2 in central
        found log4j#log4j;1.2.17 in local-m2-cache
        found net.java.dev.jets3t#jets3t;0.9.0 in central
        found org.apache.httpcomponents#httpclient;4.2.5 in local-m2-cache
        found org.apache.httpcomponents#httpcore;4.2.5 in central
        found com.jamesmurty.utils#java-xmlbuilder;0.4 in central
        found commons-lang#commons-lang;2.6 in local-m2-cache
        found commons-configuration#commons-configuration;1.6 in local-m2-cache
        found commons-digester#commons-digester;1.8 in local-m2-cache
        found commons-beanutils#commons-beanutils;1.7.0 in local-m2-cache
        found commons-beanutils#commons-beanutils-core;1.8.0 in local-m2-cache
        found org.slf4j#slf4j-api;1.7.10 in central
        found org.apache.avro#avro;1.7.4 in central
        found com.thoughtworks.paranamer#paranamer;2.3 in local-m2-cache
        found org.xerial.snappy#snappy-java;1.0.4.1 in central
        found org.apache.commons#commons-compress;1.4.1 in central
        found org.tukaani#xz;1.0 in central
        found com.google.code.gson#gson;2.2.4 in local-m2-cache
        found org.apache.hadoop#hadoop-auth;2.7.7 in central
        found org.apache.directory.server#apacheds-kerberos-codec;2.0.0-M15 in local-m2-cache
        found org.apache.directory.server#apacheds-i18n;2.0.0-M15 in local-m2-cache
        found org.apache.directory.api#api-asn1-api;1.0.0-M20 in local-m2-cache
        found org.apache.directory.api#api-util;1.0.0-M20 in local-m2-cache
        found org.apache.zookeeper#zookeeper;3.4.6 in local-m2-cache
        found org.slf4j#slf4j-log4j12;1.7.10 in central
        found io.netty#netty;3.6.2.Final in central
        found org.apache.curator#curator-framework;2.7.1 in central
        found org.apache.curator#curator-client;2.7.1 in central
        found com.jcraft#jsch;0.1.54 in spark-list
        found org.apache.curator#curator-recipes;2.7.1 in central
        found com.google.code.findbugs#jsr305;3.0.0 in local-m2-cache
        found org.apache.htrace#htrace-core;3.1.0-incubating in central
        found org.mortbay.jetty#servlet-api;2.5-20081211 in central
        found javax.servlet.jsp#jsp-api;2.1 in central
        found jline#jline;0.9.94 in central
        found junit#junit;4.11 in central
        found org.hamcrest#hamcrest-core;1.3 in central
        found com.fasterxml.jackson.core#jackson-databind;2.2.3 in central
        found com.fasterxml.jackson.core#jackson-annotations;2.2.3 in central
        found com.fasterxml.jackson.core#jackson-core;2.2.3 in central
        found com.amazonaws#aws-java-sdk;1.7.4 in central
        found joda-time#joda-time;2.10.10 in central
        [2.10.10] joda-time#joda-time;[2.2,)
        found org.scalaj#scalaj-http_2.11;2.4.2 in central
        found org.json4s#json4s-native_2.11;3.7.0-M8 in central
        found org.json4s#json4s-core_2.11;3.7.0-M8 in central
        found org.json4s#json4s-ast_2.11;3.7.0-M8 in central
        found org.json4s#json4s-scalap_2.11;3.7.0-M8 in central
        found com.thoughtworks.paranamer#paranamer;2.8 in local-m2-cache
        found com.google.guava#guava;16.0.1 in local-m2-cache
        found com.google.guava#failureaccess;1.0.1 in central
downloading /home/ariels/.ivy2/local/io.treeverse/core-247_2.11/0.1.0-SNAPSHOT/jars/core-247_2.11.jar ...
        [SUCCESSFUL ] io.treeverse#core-247_2.11;0.1.0-SNAPSHOT!core-247_2.11.jar (1ms)
downloading https://repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime_2.11/0.9.7/scalapb-runtime_2.11-0.9.7.jar ...
        [SUCCESSFUL ] com.thesamet.scalapb#scalapb-runtime_2.11;0.9.7!scalapb-runtime_2.11.jar (783ms)
downloading https://repo1.maven.org/maven2/com/thesamet/scalapb/lenses_2.11/0.9.7/lenses_2.11-0.9.7.jar ...
        [SUCCESSFUL ] com.thesamet.scalapb#lenses_2.11;0.9.7!lenses_2.11.jar (81ms)
downloading https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.8.0/protobuf-java-3.8.0.jar ...
        [SUCCESSFUL ] com.google.protobuf#protobuf-java;3.8.0!protobuf-java.jar(bundle) (263ms)
:: resolution report :: resolve 4451ms :: artifacts dl 1148ms
        :: modules in use:
        asm#asm;3.2 from central in [default]
        com.amazonaws#aws-java-sdk;1.7.4 from central in [default]
        com.fasterxml.jackson.core#jackson-annotations;2.2.3 from central in [default]
        com.fasterxml.jackson.core#jackson-core;2.2.3 from central in [default]
        com.fasterxml.jackson.core#jackson-databind;2.2.3 from central in [default]
        com.google.code.findbugs#jsr305;3.0.0 from local-m2-cache in [default]
        com.google.code.gson#gson;2.2.4 from local-m2-cache in [default]
        com.google.guava#failureaccess;1.0.1 from central in [default]
        com.google.guava#guava;16.0.1 from local-m2-cache in [default]
        com.google.protobuf#protobuf-java;3.8.0 from central in [default]
        com.jamesmurty.utils#java-xmlbuilder;0.4 from central in [default]
        com.jcraft#jsch;0.1.54 from spark-list in [default]
        com.lihaoyi#fastparse_2.11;2.1.2 from central in [default]
        com.lihaoyi#sourcecode_2.11;0.1.6 from central in [default]
        com.sun.jersey#jersey-core;1.9 from central in [default]
        com.sun.jersey#jersey-json;1.9 from central in [default]
        com.sun.jersey#jersey-server;1.9 from central in [default]
        com.sun.xml.bind#jaxb-impl;2.2.3-1 from local-m2-cache in [default]
        com.thesamet.scalapb#lenses_2.11;0.9.7 from central in [default]
        com.thesamet.scalapb#scalapb-runtime_2.11;0.9.7 from central in [default]
        com.thoughtworks.paranamer#paranamer;2.8 from local-m2-cache in [default]
        commons-beanutils#commons-beanutils;1.7.0 from local-m2-cache in [default]
        commons-beanutils#commons-beanutils-core;1.8.0 from local-m2-cache in [default]
        commons-cli#commons-cli;1.2 from local-m2-cache in [default]
        commons-codec#commons-codec;1.15 from local-m2-cache in [default]
        commons-collections#commons-collections;3.2.2 from local-m2-cache in [default]
        commons-configuration#commons-configuration;1.6 from local-m2-cache in [default]
        commons-digester#commons-digester;1.8 from local-m2-cache in [default]
        commons-httpclient#commons-httpclient;3.1 from local-m2-cache in [default]
        commons-io#commons-io;2.4 from local-m2-cache in [default]
        commons-lang#commons-lang;2.6 from local-m2-cache in [default]
        commons-logging#commons-logging;1.1.3 from local-m2-cache in [default]
        commons-net#commons-net;3.1 from local-m2-cache in [default]
        io.netty#netty;3.6.2.Final from central in [default]
        io.treeverse#core-247_2.11;0.1.0-SNAPSHOT from local-ivy-cache in [default]
        javax.activation#activation;1.1 from central in [default]
        javax.servlet#servlet-api;2.5 from central in [default]
        javax.servlet.jsp#jsp-api;2.1 from central in [default]
        javax.xml.bind#jaxb-api;2.2.2 from local-m2-cache in [default]
        javax.xml.stream#stax-api;1.0-2 from local-m2-cache in [default]
        jline#jline;0.9.94 from central in [default]
        joda-time#joda-time;2.10.10 from central in [default]
        junit#junit;4.11 from central in [default]
        log4j#log4j;1.2.17 from local-m2-cache in [default]
        net.java.dev.jets3t#jets3t;0.9.0 from central in [default]
        org.apache.avro#avro;1.7.4 from central in [default]
        org.apache.commons#commons-compress;1.4.1 from central in [default]
        org.apache.commons#commons-math3;3.1.1 from central in [default]
        org.apache.curator#curator-client;2.7.1 from central in [default]
        org.apache.curator#curator-framework;2.7.1 from central in [default]
        org.apache.curator#curator-recipes;2.7.1 from central in [default]
        org.apache.directory.api#api-asn1-api;1.0.0-M20 from local-m2-cache in [default]
        org.apache.directory.api#api-util;1.0.0-M20 from local-m2-cache in [default]
        org.apache.directory.server#apacheds-i18n;2.0.0-M15 from local-m2-cache in [default]
        org.apache.directory.server#apacheds-kerberos-codec;2.0.0-M15 from local-m2-cache in [default]
        org.apache.hadoop#hadoop-annotations;2.7.7 from central in [default]
        org.apache.hadoop#hadoop-auth;2.7.7 from central in [default]
        org.apache.hadoop#hadoop-aws;2.7.7 from central in [default]
        org.apache.hadoop#hadoop-common;2.7.7 from central in [default]
        org.apache.htrace#htrace-core;3.1.0-incubating from central in [default]
        org.apache.httpcomponents#httpclient;4.2.5 from local-m2-cache in [default]
        org.apache.httpcomponents#httpcore;4.2.5 from central in [default]
        org.apache.zookeeper#zookeeper;3.4.6 from local-m2-cache in [default]
        org.codehaus.jackson#jackson-core-asl;1.9.13 from local-m2-cache in [default]
        org.codehaus.jackson#jackson-jaxrs;1.9.13 from local-m2-cache in [default]
        org.codehaus.jackson#jackson-mapper-asl;1.9.13 from local-m2-cache in [default]
        org.codehaus.jackson#jackson-xc;1.9.13 from local-m2-cache in [default]
        org.codehaus.jettison#jettison;1.1 from local-m2-cache in [default]
        org.hamcrest#hamcrest-core;1.3 from central in [default]
        org.json4s#json4s-ast_2.11;3.7.0-M8 from central in [default]
        org.json4s#json4s-core_2.11;3.7.0-M8 from central in [default]
        org.json4s#json4s-native_2.11;3.7.0-M8 from central in [default]
        org.json4s#json4s-scalap_2.11;3.7.0-M8 from central in [default]
        org.mortbay.jetty#jetty;6.1.26 from central in [default]
        org.mortbay.jetty#jetty-sslengine;6.1.26 from central in [default]
        org.mortbay.jetty#jetty-util;6.1.26 from local-m2-cache in [default]
        org.mortbay.jetty#servlet-api;2.5-20081211 from central in [default]
        org.rocksdb#rocksdbjni;6.6.4 from central in [default]
        org.scalaj#scalaj-http_2.11;2.4.2 from central in [default]
        org.slf4j#slf4j-api;1.7.10 from central in [default]
        org.slf4j#slf4j-log4j12;1.7.10 from central in [default]
        org.tukaani#xz;1.0 from central in [default]
        org.xerial.snappy#snappy-java;1.0.4.1 from central in [default]
        xmlenc#xmlenc;0.52 from local-m2-cache in [default]
        :: evicted modules:
        com.google.guava#guava;11.0.2 by [com.google.guava#guava;16.0.1] in [default]
        commons-codec#commons-codec;1.4 by [commons-codec#commons-codec;1.15] in [default]
        com.thoughtworks.paranamer#paranamer;2.3 by [com.thoughtworks.paranamer#paranamer;2.8] in [default]
        com.google.protobuf#protobuf-java;2.5.0 by [com.google.protobuf#protobuf-java;3.8.0] in [default]
        ---------------------------------------------------------------------
        |                  |            modules            ||   artifacts   |
        |       conf       | number| search|dwnlded|evicted|| number|dwnlded|
        ---------------------------------------------------------------------
        |      default     |   88  |   5   |   4   |   4   ||   84  |   4   |
        ---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-9701fd43-edf3-4326-882f-e66c357e86f5
        confs: [default]
        4 artifacts copied, 80 already retrieved (6329kB/21ms)
21/03/10 16:09:37 WARN Utils: Your hostname, redqueen resolves to a loopback address: 127.0.1.1; using 192.168.1.87 instead (on interface wlp0s20f3)
21/03/10 16:09:37 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
21/03/10 16:09:38 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
21/03/10 16:09:42 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.
21/03/10 16:09:42 WARN Utils: Service 'SparkUI' could not bind on port 4041. Attempting port 4042.
Spark context Web UI available at http://192.168.1.87:4042
Spark context available as 'sc' (master = local, app id = local-1615385382738).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.4.7
      /_/
         
Using Scala version 2.11.12 (OpenJDK 64-Bit Server VM, Java 11.0.10)
Type in expressions to have them evaluated.
Type :help for more information.

scala> import io.treeverse._
import io.treeverse._

scala> import io.treeverse.clients._; val df = LakeFSContext.newDF(spark, "...", "d1707109d96e25202d78ed9a97b..."); df.take(10)
import io.treeverse.clients._                                                   
df: org.apache.spark.sql.DataFrame = [key: string, address: string ... 3 more fields]
res0: Array[org.apache.spark.sql.Row] = Array([_$folder$,s3://...]
```

and similarly with 3.0.1, commandline
```
ariels@redqueen:~/dev/spark-client$ spark-shell --master local --packages io.treeverse:core-301_2.12:0.1.0-SNAPSHOT  --conf spark.hadoop.lakefs.api.url=http://yoni-test.lakefs.dev/api/v1  --conf spark.hadoop.lakefs.api.access_key=AKIA... --conf spark.hadoop.lakefs.api.secret_key=... --conf spark.hadoop.fs.s3a.access.key=AKIA... --conf spark.hadoop-fs.s3a.secret.key=...
```